### PR TITLE
Add logout helper

### DIFF
--- a/estoque-vendas/src/pages/layout.js
+++ b/estoque-vendas/src/pages/layout.js
@@ -4,6 +4,10 @@ import { MdDashboard, MdInventory, MdAttachMoney, MdLogout } from "react-icons/m
 export default function Layout({ children }) {
   const router = useRouter();
   const goTo = (path) => router.push(path);
+  const logout = () => {
+    localStorage.removeItem("token");
+    router.push("/login");
+  };
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-900 text-white">
@@ -19,7 +23,7 @@ export default function Layout({ children }) {
           <button onClick={() => goTo("/sales")} title="Vendas" className="text-white text-3xl hover:text-green-400 transition">
             <MdAttachMoney />
           </button>
-          <button onClick={() => goTo("/login")} title="Logout" className="mt-auto text-red-500 text-3xl hover:text-red-700 transition">
+          <button onClick={logout} title="Logout" className="mt-auto text-red-500 text-3xl hover:text-red-700 transition">
             <MdLogout />
           </button>
         </nav>
@@ -39,7 +43,7 @@ export default function Layout({ children }) {
         <button onClick={() => goTo("/sales")} title="Vendas" className="text-white text-3xl hover:text-green-400 transition">
           <MdAttachMoney />
         </button>
-        <button onClick={() => goTo("/login")} title="Logout" className="text-red-500 text-3xl hover:text-red-700 transition">
+        <button onClick={logout} title="Logout" className="text-red-500 text-3xl hover:text-red-700 transition">
           <MdLogout />
         </button>
       </nav>


### PR DESCRIPTION
## Summary
- add logout helper that removes token and redirects to login
- wire logout helper to both logout buttons

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689418568e548330a6babf0cdafffcd2