### PR TITLE
feat: add offline-first sales sync

### DIFF
--- a/estoque-vendas/package-lock.json
+++ b/estoque-vendas/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^6.12.0",
         "bcrypt": "^6.0.0",
+        "idb": "^8.0.3",
         "jsonwebtoken": "^9.0.2",
         "next": "15.4.4",
         "prisma": "^6.12.0",
@@ -5315,6 +5316,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/estoque-vendas/package.json
+++ b/estoque-vendas/package.json
@@ -17,7 +17,8 @@
     "prisma": "^6.12.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "idb": "^8.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/estoque-vendas/prisma/migrations/20250914120000_add_offline_id_to_sale/migration.sql
+++ b/estoque-vendas/prisma/migrations/20250914120000_add_offline_id_to_sale/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Sale" ADD COLUMN "offlineId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Sale_offlineId_key" ON "Sale"("offlineId");

--- a/estoque-vendas/prisma/schema.prisma
+++ b/estoque-vendas/prisma/schema.prisma
@@ -64,6 +64,7 @@ model Sale {
   userId      Int?
   client      Client?    @relation(fields: [clientId], references: [id])
   clientId    Int?
+  offlineId   String?    @unique
   total       Float?
   payment     String?    @default("dinheiro")
   discount    Float?     @default(0)

--- a/estoque-vendas/src/lib/offlineSales.js
+++ b/estoque-vendas/src/lib/offlineSales.js
@@ -1,0 +1,49 @@
+import { openDB } from 'idb';
+
+const DB_NAME = 'sales-db';
+const STORE_NAME = 'pending-sales';
+
+async function getDb() {
+  return openDB(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'offlineId' });
+      }
+    },
+  });
+}
+
+export async function saveSaleOffline(sale) {
+  const db = await getDb();
+  await db.put(STORE_NAME, sale);
+}
+
+export async function getPendingSales() {
+  const db = await getDb();
+  return db.getAll(STORE_NAME);
+}
+
+export async function removePendingSale(offlineId) {
+  const db = await getDb();
+  await db.delete(STORE_NAME, offlineId);
+}
+
+export async function syncPendingSales() {
+  const sales = await getPendingSales();
+  for (const sale of sales) {
+    try {
+      const res = await fetch('/api/sales', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sale),
+      });
+      if (res.ok) {
+        await removePendingSale(sale.offlineId);
+      } else {
+        console.error('Falha ao sincronizar venda', sale.offlineId);
+      }
+    } catch (err) {
+      console.error('Erro de sincronização', err);
+    }
+  }
+}

--- a/estoque-vendas/src/pages/api/sales.js
+++ b/estoque-vendas/src/pages/api/sales.js
@@ -21,17 +21,23 @@ export default async function handler(req, res) {
   }
 
   if (req.method === 'POST') {
-    const { items } = req.body;
+    const { items, offlineId } = req.body;
 
     if (!items || !Array.isArray(items) || items.length === 0) {
       return res.status(400).json({ message: 'Itens da venda são obrigatórios' });
     }
 
     try {
+      if (offlineId) {
+        const existing = await prisma.sale.findUnique({ where: { offlineId } });
+        if (existing) return res.status(200).json(existing);
+      }
+
       const total = items.reduce((acc, item) => acc + item.price * item.qty, 0);
 
       const sale = await prisma.sale.create({
         data: {
+          offlineId,
           total,
           items: {
             create: items.map((item) => ({


### PR DESCRIPTION
## Summary
- add IndexedDB helper for pending sales and automatic sync
- integrate offline-first logic into dashboard sales flow
- prevent duplicate sales via unique offline ids and prisma schema change

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952ef1614c8330bbfa59480d836bbb