### PR TITLE
Exibe nome do cliente nas comandas

### DIFF
--- a/estoque-vendas/prisma/migrations/20250920000000_add_client_name_to_comanda/migration.sql
+++ b/estoque-vendas/prisma/migrations/20250920000000_add_client_name_to_comanda/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Comanda" ADD COLUMN "clientName" TEXT;

--- a/estoque-vendas/prisma/schema.prisma
+++ b/estoque-vendas/prisma/schema.prisma
@@ -93,6 +93,7 @@ model Comanda {
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt
   status    String        @default("aberta")
+  clientName String?
   itens     ComandaItem[]
 }
 

--- a/estoque-vendas/src/pages/api/comandas/index.js
+++ b/estoque-vendas/src/pages/api/comandas/index.js
@@ -17,7 +17,8 @@ export default async function handler(req, res) {
       }
     case 'POST':
       try {
-        const comanda = await prisma.comanda.create({ data: {} });
+        const { clientName } = req.body || {};
+        const comanda = await prisma.comanda.create({ data: { clientName } });
         return res.status(201).json(comanda);
       } catch (err) {
         console.error(err);

--- a/estoque-vendas/src/pages/dashboard.js
+++ b/estoque-vendas/src/pages/dashboard.js
@@ -230,7 +230,7 @@ export default function Dashboard() {
         setSelectedComanda(null);
         setShowModal(false);
       },
-      'Venda finalizada com sucesso!'
+      `Comanda de ${comanda.clientName || 'Cliente'} finalizada com sucesso!`
     );
   };
 
@@ -354,7 +354,7 @@ export default function Dashboard() {
                       onClick={() => addItemsToComanda(c.id)}
                       className="w-full bg-gray-700 py-2 rounded mb-2 hover:bg-gray-600"
                     >
-                      {`Comanda #${c.id}`}
+                      {`Comanda #${c.id} - Cliente: ${c.clientName || 'N/A'} - Status: ${c.status}`}
                     </button>
                   ))}
                 </div>
@@ -369,14 +369,19 @@ export default function Dashboard() {
                         onClick={() => setSelectedComanda(c.id)}
                         className={`w-full py-2 rounded ${selectedComanda === c.id ? 'bg-green-700' : 'bg-gray-700 hover:bg-gray-600'}`}
                       >
-                        {`Comanda #${c.id}`}
+                        {`Comanda #${c.id} - Cliente: ${c.clientName || 'N/A'} - Status: ${c.status}`}
                       </button>
                     ))}
                   </div>
 
                   {selectedComanda && (
                     <div className="bg-gray-700 p-4 rounded mb-4 max-h-64 overflow-y-auto">
-                      <h3 className="text-lg font-bold mb-2">Itens da Comanda</h3>
+                      <h3 className="text-lg font-bold mb-2">
+                        {(() => {
+                          const c = comandas.find((c) => c.id === selectedComanda);
+                          return `Comanda #${c?.id} - Cliente: ${c?.clientName || 'N/A'}`;
+                        })()}
+                      </h3>
                       {comandas
                         .find((c) => c.id === selectedComanda)
                         ?.items.map((item, idx) => (


### PR DESCRIPTION
## Summary
- Adiciona campo `clientName` às comandas e persistência no banco
- Mostra nome do cliente na criação, seleção e finalização de comandas
- Inclui migração de banco para nova coluna de cliente

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689553d2054c8330aa18f223959e88a2