### PR TITLE
feat: add haptic and color feedback to buttons

### DIFF
--- a/estoque-vendas/src/lib/haptic.js
+++ b/estoque-vendas/src/lib/haptic.js
@@ -1,0 +1,5 @@
+export function triggerVibration() {
+  if (typeof navigator !== 'undefined' && navigator.vibrate) {
+    navigator.vibrate(100);
+  }
+}

--- a/estoque-vendas/src/pages/comandas.js
+++ b/estoque-vendas/src/pages/comandas.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import Layout from './layout';
+import { triggerVibration } from '@/lib/haptic';
 
 export default function Comandas() {
   const [comandas, setComandas] = useState([]);
@@ -18,6 +19,7 @@ export default function Comandas() {
   }, []);
 
   const handleCreateComanda = async () => {
+    triggerVibration();
     const clientName = prompt('Informe o nome do cliente:');
     if (!clientName) {
       return alert('Nome do cliente é obrigatório!');
@@ -40,6 +42,7 @@ export default function Comandas() {
   };
 
   const handleFinalizeComanda = async (comandaId) => {
+    triggerVibration();
     try {
       const res = await fetch(`/api/comandas/${comandaId}/finalize`, {
         method: 'POST',

--- a/estoque-vendas/src/pages/dashboard.js
+++ b/estoque-vendas/src/pages/dashboard.js
@@ -7,6 +7,7 @@ import {
 } from 'react-icons/md';
 import { useRouter } from 'next/router';
 import Layout from './layout';
+import { triggerVibration } from '@/lib/haptic';
 import { saveSaleOffline, syncPendingSales } from '@/lib/offlineSales';
 
 export default function Dashboard() {
@@ -172,6 +173,7 @@ export default function Dashboard() {
   };
 
   const handleCreateComanda = async () => {
+    triggerVibration();
     const clientName = prompt('Informe o nome do cliente:');
     if (!clientName) return alert('Nome do cliente é obrigatório!');
     try {
@@ -213,6 +215,7 @@ export default function Dashboard() {
   };
 
   const handleFinalizeComanda = () => {
+    triggerVibration();
     setShowModal(true);
     setModalType('finalize');
   };
@@ -328,13 +331,19 @@ export default function Dashboard() {
                 Finalizar Venda
               </button>
               <div className="mt-4 space-y-2">
-                <button onClick={handleCreateComanda} className="bg-yellow-600 w-full py-2 rounded hover:bg-yellow-700">
+                <button
+                  onClick={handleCreateComanda}
+                  className="criar-comanda-btn bg-yellow-600 w-full py-2 rounded hover:bg-yellow-700"
+                >
                   Criar Comanda
                 </button>
                 <button onClick={handleAddToComanda} className="bg-purple-600 w-full py-2 rounded hover:bg-purple-700">
                   Adicionar à Comanda
                 </button>
-                <button onClick={handleFinalizeComanda} className="bg-pink-600 w-full py-2 rounded hover:bg-pink-700">
+                <button
+                  onClick={handleFinalizeComanda}
+                  className="finalizar-comanda-btn bg-pink-600 w-full py-2 rounded hover:bg-pink-700"
+                >
                   Finalizar Comanda
                 </button>
               </div>

--- a/estoque-vendas/src/pages/products.js
+++ b/estoque-vendas/src/pages/products.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import Layout from './layout';
+import { triggerVibration } from '@/lib/haptic';
 
 export default function ProductsPage() {
   const [products, setProducts] = useState([]);
@@ -48,6 +49,7 @@ export default function ProductsPage() {
   };
 
   const openModalForNew = () => {
+    triggerVibration();
     setEditingProduct(null);
     setForm({
       name: '',
@@ -240,7 +242,7 @@ export default function ProductsPage() {
             </button>
             <button
               onClick={openModalForNew}
-              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+              className="adicionar-produto-btn bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
             >
               Adicionar Produto
             </button>

--- a/estoque-vendas/src/styles/globals.css
+++ b/estoque-vendas/src/styles/globals.css
@@ -40,3 +40,7 @@ button:active {
 .finalizar-comanda-btn:active {
   background-color: #f44336;
 }
+
+.adicionar-produto-btn:active {
+  background-color: #45a049;
+}


### PR DESCRIPTION
## Summary
- add shared haptic trigger utility
- provide vibration and active color feedback for comanda and product buttons

## Testing
- `npm test` *(fails: API Comandas › POST /api/comandas/:id/finalize › valida ausência de método de pagamento)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689556aaab108330ac75b11a17e5a78c