### PR TITLE
Refactor status page with reusable hook

### DIFF
--- a/estoque-vendas/src/components/StatusTests.js
+++ b/estoque-vendas/src/components/StatusTests.js
@@ -1,0 +1,29 @@
+export default function StatusTests({ tests }) {
+  if (!tests) return null;
+
+  const { lastRun, stats, details = [], logs } = tests;
+  const { total, passed, failed, runtime } = stats;
+
+  return (
+    <>
+      <h2>Testes</h2>
+      <p>
+        Última execução: {new Date(lastRun).toLocaleString()} | Total: {total} | Passaram: {passed} | Falharam: {failed} | Tempo: {runtime}ms
+      </p>
+      <ul>
+        {details.map((t) => (
+          <li key={t.name} style={{ marginBottom: '0.5rem' }}>
+            {t.name} - {t.status} - {t.duration}ms
+            {t.status !== 'passed' && <pre>{t.message}</pre>}
+          </li>
+        ))}
+      </ul>
+      {logs && (
+        <div>
+          <h3>Logs</h3>
+          <pre>{logs}</pre>
+        </div>
+      )}
+    </>
+  );
+}

--- a/estoque-vendas/src/hooks/useStatus.js
+++ b/estoque-vendas/src/hooks/useStatus.js
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export default function useStatus(refreshInterval = 10000) {
+  const [status, setStatus] = useState(null);
+  const [error, setError] = useState(null);
+
+  const fetchStatus = useCallback(async (signal) => {
+    try {
+      const res = await fetch('/api/status', { signal });
+      if (!res.ok) throw new Error('Failed to fetch status');
+      const json = await res.json();
+      setStatus(json);
+      setError(null);
+    } catch (err) {
+      if (err.name !== 'AbortError') setError(err.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchStatus(controller.signal);
+    const interval = setInterval(() => {
+      const ctrl = new AbortController();
+      fetchStatus(ctrl.signal);
+    }, refreshInterval);
+    return () => {
+      controller.abort();
+      clearInterval(interval);
+    };
+  }, [fetchStatus, refreshInterval]);
+
+  return { status, error, loading: !status && !error };
+}

--- a/estoque-vendas/src/pages/status.js
+++ b/estoque-vendas/src/pages/status.js
@@ -1,64 +1,23 @@
-import { useEffect, useState } from 'react';
+import StatusTests from '../components/StatusTests';
+import useStatus from '../hooks/useStatus';
 
 export default function StatusPage() {
-  const [data, setData] = useState(null);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const fetchStatus = async () => {
-      try {
-        const res = await fetch('/api/status');
-        const json = await res.json();
-        if (!cancelled) {
-          setData(json);
-          setError(null);
-        }
-      } catch (err) {
-        if (!cancelled) setError(err.message);
-      }
-    };
-
-    fetchStatus();
-    const interval = setInterval(fetchStatus, 10000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, []);
+  const { status, error, loading } = useStatus();
 
   if (error) return <div>Erro: {error}</div>;
-  if (!data) return <div>Carregando...</div>;
+  if (loading) return <div>Carregando...</div>;
+
+  const { version, lastCommit, apiStatus, tests } = status;
 
   return (
     <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
       <h1>Status do Sistema</h1>
-      <p>Versão: {data.version}</p>
-      {data.lastCommit && (
-        <p>Último deploy: {new Date(data.lastCommit).toLocaleString()}</p>
+      <p>Versão: {version}</p>
+      {lastCommit && (
+        <p>Último deploy: {new Date(lastCommit).toLocaleString()}</p>
       )}
-      <p>Status da API: {data.apiStatus}</p>
-      <h2>Testes</h2>
-      <p>
-        Última execução:{' '}
-        {new Date(data.tests.lastRun).toLocaleString()} | Total:{' '}
-        {data.tests.stats.total} | Passaram: {data.tests.stats.passed} | Falharam: {data.tests.stats.failed} | Tempo:{' '}
-        {data.tests.stats.runtime}ms
-      </p>
-      <ul>
-        {data.tests.details.map((t) => (
-          <li key={t.name} style={{ marginBottom: '0.5rem' }}>
-            {t.name} - {t.status} - {t.duration}ms
-            {t.status !== 'passed' && <pre>{t.message}</pre>}
-          </li>
-        ))}
-      </ul>
-      {data.tests.logs && (
-        <div>
-          <h3>Logs</h3>
-          <pre>{data.tests.logs}</pre>
-        </div>
-      )}
+      <p>Status da API: {apiStatus}</p>
+      <StatusTests tests={tests} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `useStatus` hook to handle status polling with cleanup and error handling
- extract `StatusTests` component to render test information
- simplify status page using new hook and component

## Testing
- `npm test` (fails: 1 failed, 23 passed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bd8a73488330aec8455af2f33c3f