### PR TITLE
feat: allow creating categories from product form

### DIFF
--- a/estoque-vendas/src/components/forms/CreateCategoryModal.js
+++ b/estoque-vendas/src/components/forms/CreateCategoryModal.js
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+// Modal with form to create a new category
+export default function CreateCategoryModal({ isOpen, onClose, onCreated }) {
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+
+  // Send form data to API and handle feedback
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (!name.trim()) {
+      setError('Nome é obrigatório');
+      return;
+    }
+    try {
+      const res = await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.message || 'Erro ao criar categoria');
+        return;
+      }
+      const newCategory = await res.json();
+      onCreated(newCategory);
+      setName('');
+      onClose();
+    } catch (err) {
+      setError('Erro ao criar categoria');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50">
+      <div className="bg-gray-900 p-6 rounded shadow-lg w-full max-w-md relative">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-white text-xl font-bold hover:text-red-500"
+          aria-label="Fechar"
+        >
+          ×
+        </button>
+          <h2 className="text-2xl mb-4">Criar Categoria</h2>
+          <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Nome da categoria"
+            className="w-full p-3 rounded bg-gray-800 border border-gray-600"
+            required
+          />
+          {error && <p className="text-red-500">{error}</p>}
+          <div className="flex justify-end space-x-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2 bg-red-600 rounded hover:bg-red-700"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="px-6 py-2 bg-blue-600 rounded hover:bg-blue-700"
+            >
+              Salvar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/estoque-vendas/src/hooks/useCategories.js
+++ b/estoque-vendas/src/hooks/useCategories.js
@@ -1,0 +1,26 @@
+import { useState, useCallback } from 'react';
+
+// Hook to manage product categories
+export default function useCategories() {
+  const [categories, setCategories] = useState([]);
+
+  // Fetch categories from API
+  const loadCategories = useCallback(async () => {
+    try {
+      const res = await fetch('/api/categories');
+      const data = await res.json();
+      setCategories(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('Erro ao buscar categorias:', err);
+    }
+  }, []);
+
+  // Insert a newly created category into local state
+  const addCategory = useCallback((category) => {
+    setCategories((prev) =>
+      [...prev, category].sort((a, b) => a.name.localeCompare(b.name))
+    );
+  }, []);
+
+  return { categories, loadCategories, addCategory };
+}

--- a/estoque-vendas/src/pages/api/categories.js
+++ b/estoque-vendas/src/pages/api/categories.js
@@ -1,13 +1,42 @@
 import { prisma } from '@/lib/prisma';
 
 export default async function handler(req, res) {
-  try {
-    const categories = await prisma.category.findMany({
-      orderBy: { name: 'asc' },
-    });
-    res.status(200).json(categories);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'Erro ao buscar categorias' });
+  const { method } = req;
+
+  switch (method) {
+    case 'GET':
+      try {
+        const categories = await prisma.category.findMany({
+          orderBy: { name: 'asc' },
+        });
+        return res.status(200).json(categories);
+      } catch (err) {
+        console.error(err);
+        return res.status(500).json({ message: 'Erro ao buscar categorias' });
+      }
+    case 'POST':
+      try {
+        const { name } = req.body;
+        if (!name) {
+          return res.status(400).json({ message: 'Nome é obrigatório' });
+        }
+        // Save new category
+        const category = await prisma.category.create({
+          data: { name },
+        });
+        return res.status(201).json(category);
+      } catch (err) {
+        // Handle unique constraint violation
+        if (err.code === 'P2002') {
+          return res
+            .status(409)
+            .json({ message: 'Categoria já existe' });
+        }
+        console.error(err);
+        return res.status(500).json({ message: 'Erro ao criar categoria' });
+      }
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      return res.status(405).json({ message: `Método ${method} não permitido` });
   }
 }

--- a/estoque-vendas/src/pages/products.js
+++ b/estoque-vendas/src/pages/products.js
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react';
 import Layout from './layout';
 import { triggerVibration } from '@/lib/haptic';
+import CreateCategoryModal from '@/components/forms/CreateCategoryModal';
+import useCategories from '@/hooks/useCategories';
 
 export default function ProductsPage() {
   const [products, setProducts] = useState([]);
-  const [categories, setCategories] = useState([]);
+  const { categories, loadCategories, addCategory } = useCategories(); // hook manages categories
   const [editingProduct, setEditingProduct] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState(null);
@@ -22,11 +24,12 @@ export default function ProductsPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [stockModalOpen, setStockModalOpen] = useState(false);
   const [stockForm, setStockForm] = useState({ productId: '', quantity: '' });
+  const [categoryModalOpen, setCategoryModalOpen] = useState(false); // controls category modal
 
   useEffect(() => {
     fetchProducts();
-    fetchCategories();
-  }, []);
+    loadCategories();
+  }, []); // load initial data
 
   const fetchProducts = async () => {
     try {
@@ -38,15 +41,6 @@ export default function ProductsPage() {
     }
   };
 
-  const fetchCategories = async () => {
-    try {
-      const res = await fetch('/api/categories');
-      const data = await res.json();
-      setCategories(Array.isArray(data) ? data : []);
-    } catch (error) {
-      console.error('Erro ao buscar categorias:', error);
-    }
-  };
 
   const openModalForNew = () => {
     triggerVibration();
@@ -79,6 +73,11 @@ export default function ProductsPage() {
 
   const closeModal = () => {
     setModalOpen(false);
+  };
+
+  const handleCategoryCreated = (category) => {
+    addCategory(category); // refresh list with new category
+    setForm((prev) => ({ ...prev, categoryId: category.id })); // select created category
   };
 
   const handleInputChange = (e) => {
@@ -234,18 +233,25 @@ export default function ProductsPage() {
               <option value="updatedAt">Última Modificação</option>
               <option value="name">Ordem Alfabética</option>
             </select>
-            <button
-              onClick={() => setStockModalOpen(true)}
-              className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded"
-            >
-              Adicionar Estoque
-            </button>
-            <button
-              onClick={openModalForNew}
-              className="adicionar-produto-btn bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
-            >
-              Adicionar Produto
-            </button>
+              <button
+                onClick={() => setStockModalOpen(true)}
+                className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded"
+              >
+                Adicionar Estoque
+              </button>
+              <button
+                onClick={openModalForNew}
+                className="adicionar-produto-btn bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded"
+              >
+                Adicionar Produto
+              </button>
+              {/* open modal to create a new category */}
+              <button
+                onClick={() => setCategoryModalOpen(true)}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+              >
+                Criar Categoria
+              </button>
           </div>
         </div>
 
@@ -548,6 +554,12 @@ export default function ProductsPage() {
             </div>
           </div>
         )}
+        {/* modal to create categories */}
+        <CreateCategoryModal
+          isOpen={categoryModalOpen}
+          onClose={() => setCategoryModalOpen(false)}
+          onCreated={handleCategoryCreated}
+        />
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- add modal to create categories from products page
- refresh category list via custom hook
- support category creation in API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689660ae810c833098671133efa26ff3