### PR TITLE
Add sales reporting dashboard with profit and inventory metrics

### DIFF
--- a/estoque-vendas/src/components/ReportTable.js
+++ b/estoque-vendas/src/components/ReportTable.js
@@ -1,0 +1,26 @@
+export default function ReportTable({ headers, rows }) {
+  return (
+    <table className="min-w-full mb-6 bg-white text-gray-800">
+      <thead>
+        <tr>
+          {headers.map((h) => (
+            <th key={h} className="px-4 py-2 border-b text-left">
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr key={idx} className={idx % 2 === 0 ? 'bg-gray-100' : ''}>
+            {row.map((cell, cIdx) => (
+              <td key={cIdx} className="px-4 py-2 border-b">
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/estoque-vendas/src/pages/api/reports.js
+++ b/estoque-vendas/src/pages/api/reports.js
@@ -1,0 +1,67 @@
+import { prisma } from '@/lib/prisma';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Método não permitido' });
+  }
+
+  try {
+    // vendas diárias e mensais
+    const sales = await prisma.sale.findMany({ select: { createdAt: true, total: true } });
+
+    const dailyMap = {};
+    const monthlyMap = {};
+    sales.forEach((s) => {
+      const date = s.createdAt.toISOString().split('T')[0];
+      dailyMap[date] = (dailyMap[date] || 0) + (s.total || 0);
+
+      const month = `${String(s.createdAt.getMonth() + 1).padStart(2, '0')}/${s.createdAt.getFullYear()}`;
+      monthlyMap[month] = (monthlyMap[month] || 0) + (s.total || 0);
+    });
+
+    const dailySales = Object.entries(dailyMap).map(([date, total]) => ({ date, total }));
+    const monthlySales = Object.entries(monthlyMap).map(([month, total]) => ({ month, total }));
+
+    // produtos para margem e estoque
+    const products = await prisma.product.findMany({
+      select: { name: true, price: true, costPrice: true, stock: true },
+    });
+
+    const profitItems = products.map((p) => {
+      const price = p.price || 0;
+      const cost = p.costPrice || 0;
+      return { name: p.name || '', price, costPrice: cost, margin: price - cost };
+    });
+    const totalMargin = profitItems.reduce((acc, p) => acc + p.margin, 0);
+
+    const stockItems = products.map((p) => {
+      const price = p.price || 0;
+      const stock = p.stock || 0;
+      return { name: p.name || '', stock, stockValue: price * stock };
+    });
+    const totalStockValue = stockItems.reduce((acc, p) => acc + p.stockValue, 0);
+
+    // vendas por categoria
+    const saleItems = await prisma.saleItem.findMany({
+      include: { product: { include: { category: true } } },
+    });
+    const categoryMap = {};
+    saleItems.forEach((item) => {
+      const category = item.product?.category?.name || 'Sem categoria';
+      const total = (item.price || 0) * (item.quantity || 0);
+      categoryMap[category] = (categoryMap[category] || 0) + total;
+    });
+    const salesByCategory = Object.entries(categoryMap).map(([category, total]) => ({ category, total }));
+
+    return res.status(200).json({
+      dailySales,
+      monthlySales,
+      profitMargins: { items: profitItems, total: totalMargin },
+      salesByCategory,
+      stockValues: { items: stockItems, total: totalStockValue },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: 'Erro ao gerar relatório' });
+  }
+}

--- a/estoque-vendas/src/pages/layout.js
+++ b/estoque-vendas/src/pages/layout.js
@@ -5,6 +5,7 @@ import {
   MdAttachMoney,
   MdLogout,
   MdReceiptLong,
+  MdAnalytics,
 } from "react-icons/md";
 
 export default function Layout({ children }) {
@@ -32,6 +33,9 @@ export default function Layout({ children }) {
           <button onClick={() => goTo("/sales")} title="Vendas" className="text-white text-3xl hover:text-green-400 transition">
             <MdAttachMoney />
           </button>
+          <button onClick={() => goTo("/reports")} title="Relatórios" className="text-white text-3xl hover:text-green-400 transition">
+            <MdAnalytics />
+          </button>
           <button onClick={logout} title="Logout" className="mt-auto text-red-500 text-3xl hover:text-red-700 transition">
             <MdLogout />
           </button>
@@ -54,6 +58,9 @@ export default function Layout({ children }) {
         </button>
         <button onClick={() => goTo("/sales")} title="Vendas" className="text-white text-3xl hover:text-green-400 transition">
           <MdAttachMoney />
+        </button>
+        <button onClick={() => goTo("/reports")} title="Relatórios" className="text-white text-3xl hover:text-green-400 transition">
+          <MdAnalytics />
         </button>
         <button onClick={logout} title="Logout" className="text-red-500 text-3xl hover:text-red-700 transition">
           <MdLogout />

--- a/estoque-vendas/src/pages/reports.js
+++ b/estoque-vendas/src/pages/reports.js
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import Layout from './layout';
+import ReportTable from '@/components/ReportTable';
+
+export default function ReportsPage() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/reports')
+      .then((res) => res.json())
+      .then(setData)
+      .catch((err) => console.error('Erro ao carregar relatórios', err));
+  }, []);
+
+  if (!data) {
+    return (
+      <Layout>
+        <p>Carregando...</p>
+      </Layout>
+    );
+  }
+
+  const { dailySales, monthlySales, profitMargins, salesByCategory, stockValues } = data;
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-bold mb-4">Relatórios</h1>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Vendas Diárias</h2>
+        <ReportTable
+          headers={['Data', 'Total de Vendas']}
+          rows={dailySales.map((d) => [d.date, d.total.toFixed(2)])}
+        />
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Vendas Mensais</h2>
+        <ReportTable
+          headers={['Mês', 'Total de Vendas']}
+          rows={monthlySales.map((m) => [m.month, m.total.toFixed(2)])}
+        />
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Margem de Lucro</h2>
+        <ReportTable
+          headers={['Produto', 'Preço', 'Custo', 'Margem Líquida']}
+          rows={profitMargins.items.map((p) => [
+            p.name,
+            p.price.toFixed(2),
+            p.costPrice.toFixed(2),
+            p.margin.toFixed(2),
+          ])}
+        />
+        <p className="font-semibold">Total de Margem: {profitMargins.total.toFixed(2)}</p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Vendas por Categoria</h2>
+        <ReportTable
+          headers={['Categoria', 'Total Vendido']}
+          rows={salesByCategory.map((c) => [c.category, c.total.toFixed(2)])}
+        />
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-2">Valor do Estoque</h2>
+        <ReportTable
+          headers={['Produto', 'Quantidade', 'Valor em Estoque']}
+          rows={stockValues.items.map((s) => [
+            s.name,
+            s.stock,
+            s.stockValue.toFixed(2),
+          ])}
+        />
+        <p className="font-semibold">Valor Total do Estoque: {stockValues.total.toFixed(2)}</p>
+      </section>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoint to aggregate daily and monthly sales, profit margins, sales by category, and stock value
- add reports page with tables for key sales metrics
- extend layout navigation with reports link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896abd2a4148330ad25b7a4997a030e